### PR TITLE
Add configurable Client options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,14 @@ Share the relevant pages/databases with the integration.
 Environment variables:
 NOTION_API_KEY (required)
 NOTION_VERSION (optional, defaults to 2022-06-28)
+
+Quick Start
+
+```go
+client := notion.NewClient(
+    os.Getenv("NOTION_API_KEY"),
+    os.Getenv("NOTION_VERSION"),
+    notion.WithTimeout(10*time.Second),
+    // notion.WithHTTPClient(customHTTPClient),
+)
+```


### PR DESCRIPTION
## Summary
- introduce ClientOption pattern with WithHTTPClient and WithTimeout helpers
- allow NewClient to accept functional options for customization
- document option usage in README Quick Start

## Testing
- `go vet ./...` (fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)
- `go test ./...` (fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68acbb5de93083209fc103b64bf1e87f