### PR TITLE
Add Notion database search example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,6 @@ Share the relevant pages/databases with the integration.
 Environment variables:
 NOTION_API_KEY (required)
 NOTION_VERSION (optional, defaults to 2022-06-28)
+
+More examples
+examples/database/main.go — Search a Notion database with SearchNotionDatabase.

--- a/examples/database/main.go
+++ b/examples/database/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	notion "github.com/your_org/notion-go-agents"
+)
+
+func main() {
+	apiKey := os.Getenv("NOTION_API_KEY")
+	databaseID := os.Getenv("DATABASE_ID")
+	if apiKey == "" || databaseID == "" {
+		log.Fatal("NOTION_API_KEY and DATABASE_ID must be set")
+	}
+	client := notion.NewClient(apiKey, os.Getenv("NOTION_VERSION"))
+	ctx := context.Background()
+	pages, err := SearchNotionDatabase(ctx, client, databaseID)
+	if err != nil {
+		log.Fatalf("search failed: %v", err)
+	}
+	for _, pg := range pages {
+		title := notion.ExtractNotionTitle(pg.Properties)
+		props := notion.SelectPrintableProperties(pg.Properties)
+		bts, _ := json.MarshalIndent(props, "", "  ")
+		fmt.Printf("%s\n%s\n\n", title, bts)
+	}
+}
+
+func SearchNotionDatabase(ctx context.Context, c *notion.Client, databaseID string) ([]*notion.NotionPage, error) {
+	resp, err := c.QueryDatabase(ctx, databaseID, notion.NotionDatabaseQueryRequest{})
+	if err != nil {
+		return nil, err
+	}
+	pages := make([]*notion.NotionPage, 0, len(resp.Results))
+	for _, raw := range resp.Results {
+		var pg notion.NotionPage
+		if err := json.Unmarshal(raw, &pg); err != nil {
+			continue
+		}
+		pages = append(pages, &pg)
+	}
+	return pages, nil
+}


### PR DESCRIPTION
## Summary
- add database search example using SearchNotionDatabase
- reference new example in README

## Testing
- `go test ./...` *(fails: directory prefix . does not contain main module or its selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68acbb50285c83208afc7fcb9c28c0c8