### PR TITLE
Expose Notion page properties in search helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Notion KB for Go Agents
 A lightweight Go package for using Notion as a knowledge base in LLM-powered agents. It wraps Notion’s REST API with a small, composable client, provides helpers for querying databases and pages, and includes a Markdown converter for Notion blocks.
+
 Features
 Typed client: Minimal Client for Notion REST calls.
 Database querying: Fetch pages from a Notion database (with pagination support).
@@ -7,13 +8,27 @@ Workspace search: Search Notion and filter to pages.
 Page retrieval: Fetch page metadata and properties.
 Markdown conversion: Convert Notion page blocks into readable Markdown.
 Utilities: Extract page titles and select printable properties.
+
+Example
+```
+client := notion.NewClient(os.Getenv("NOTION_API_KEY"), "")
+pages, _ := notion.SearchWorkspace(ctx, client, notion.NotionSearchRequest{Query: "docs"}, 1)
+for _, pg := range pages {
+    fmt.Println(pg.Title)
+    fmt.Println(pg.Properties)
+    fmt.Println(pg.Markdown)
+}
+```
+
 Folder structure
 pkg/notion/
 client.go — Notion Client and HTTP request wrapper
 types.go — Request/response and model types (search, database, page)
 api.go — High-level API methods: SearchPages, GetPage, QueryDatabase
+helpers.go — Higher level helpers: SearchWorkspace, SearchNotionDatabase, GetPageContent
 extract.go — Helpers: ExtractNotionTitle, SelectPrintableProperties
 markdown.go — NotionMarkdownConverter to render blocks as Markdown
+
 Requirements
 Go: 1.21+ (recommended)
 Notion Integration:

--- a/examples/main.go
+++ b/examples/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"notion"
+)
+
+func main() {
+	apiKey := os.Getenv("NOTION_API_KEY")
+	if apiKey == "" {
+		log.Fatal("NOTION_API_KEY is required")
+	}
+	client := notion.NewClient(apiKey, "")
+	ctx := context.Background()
+	pages, err := notion.SearchWorkspace(ctx, client, notion.NotionSearchRequest{Query: "docs"}, 1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, pg := range pages {
+		fmt.Println("Title:", pg.Title)
+		fmt.Println("Properties:", pg.Properties)
+		fmt.Println("Content:", pg.Markdown)
+	}
+}

--- a/helpers.go
+++ b/helpers.go
@@ -1,0 +1,91 @@
+package notion
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+type PageContent struct {
+	ID         string
+	Title      string
+	Markdown   string
+	URL        string
+	Properties map[string]any
+}
+
+func GetPageContent(ctx context.Context, client *Client, pageID string) (*PageContent, error) {
+	pg, err := client.GetPage(ctx, pageID)
+	if err != nil {
+		return nil, err
+	}
+	conv := NewNotionMarkdownConverter(client)
+	md, err := conv.ConvertPageToMarkdown(ctx, pageID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert page to markdown: %w", err)
+	}
+	title := ExtractNotionTitle(pg.Properties)
+	props := SelectPrintableProperties(pg.Properties)
+	url := pg.PublicURL
+	if url == "" {
+		url = pg.URL
+	}
+	return &PageContent{
+		ID:         pg.ID,
+		Title:      title,
+		Markdown:   md,
+		URL:        url,
+		Properties: props,
+	}, nil
+}
+
+func SearchWorkspace(ctx context.Context, client *Client, req NotionSearchRequest, limit int) ([]PageContent, error) {
+	ids, err := client.SearchPages(ctx, req, limit)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]PageContent, 0, len(ids))
+	for _, id := range ids {
+		pc, err := GetPageContent(ctx, client, id)
+		if err != nil {
+			continue
+		}
+		out = append(out, *pc)
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func SearchNotionDatabase(ctx context.Context, client *Client, databaseID string, req NotionDatabaseQueryRequest, limit int) ([]PageContent, error) {
+	req.PageSize = 100
+	var out []PageContent
+	cursor := ""
+	for {
+		req.StartCursor = cursor
+		resp, err := client.QueryDatabase(ctx, databaseID, req)
+		if err != nil {
+			return nil, err
+		}
+		for _, raw := range resp.Results {
+			var pg NotionPage
+			if err := json.Unmarshal(raw, &pg); err != nil {
+				continue
+			}
+			pc, err := GetPageContent(ctx, client, pg.ID)
+			if err != nil {
+				continue
+			}
+			out = append(out, *pc)
+			if limit > 0 && len(out) >= limit {
+				return out[:limit], nil
+			}
+		}
+		if !resp.HasMore || resp.NextCursor == "" {
+			break
+		}
+		cursor = resp.NextCursor
+	}
+	return out, nil
+}


### PR DESCRIPTION
## Summary
- expose printable page properties in `PageContent`
- propagate properties through workspace and database searches
- document property usage in README and example

## Testing
- `GO111MODULE=off go build .`


------
https://chatgpt.com/codex/tasks/task_e_68acbb3ffcdc8320973bd53c9fb0b09b